### PR TITLE
Fix chat toolbar resize bug

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -680,6 +680,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			override protected function updateDisplayList(unscaledWidth:Number, unscaledHeight:Number):void {
 				super.updateDisplayList(unscaledWidth, unscaledHeight);
 
+				// Force validation before evaluation of toolbar width
+				validateNow();
+
 				const paddingHeight:int = 5;
 				const paddingWidth:int = 5;
 


### PR DESCRIPTION
The ChatToolbar width depends on the ChatCanvas width. If the ChatBox is not
validated before the evaluation of the ChatToolbar width, the ChatCanvas might
have an old value. This results in a wrong ChatToolbar width.
