### PR TITLE
iOS video support

### DIFF
--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
@@ -27,8 +27,10 @@ import org.red5.server.api.IConnection;
 import org.red5.server.api.Red5;
 import org.red5.server.api.scope.IScope;
 import org.red5.server.api.stream.IBroadcastStream;
+import org.red5.server.api.stream.IPlayItem;
 import org.red5.server.api.stream.IServerStream;
 import org.red5.server.api.stream.IStreamListener;
+import org.red5.server.api.stream.ISubscriberStream;
 import org.red5.server.stream.ClientBroadcastStream;
 import org.slf4j.Logger;
 import com.google.gson.Gson;
@@ -187,7 +189,19 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
     private Long genTimestamp() {
     	return TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
     }
-    
+
+	@Override
+	public void streamPlayItemPlay(ISubscriberStream stream, IPlayItem item, boolean isLive) {
+		String streamName = item.getName();
+		// Trim streamName
+		streamName = streamName.replaceAll("^/", "");
+
+		if(streamName.startsWith("h263/")) {
+			log.info("Spawn FFMpeg to convert H264 to H263 for stream [{}]", streamName);
+			//TODO: spawn ffmpeg
+		}
+	}
+
     @Override
     public void streamBroadcastClose(IBroadcastStream stream) {
       super.streamBroadcastClose(stream);   	

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
@@ -206,9 +206,9 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
 	public void streamPlayItemPlay(ISubscriberStream stream, IPlayItem item, boolean isLive) {
 		String streamName = item.getName();
 
-		log.debug("Stream requested [{}]", streamName);
 		if(isH263Stream(stream)) {
 			String origin = streamName.replaceAll(H263Converter.H263PREFIX, "");
+			log.trace("Detected H263 stream request [{}]", streamName);
 
 			synchronized (h263Converters) {
 				// Check if a new stream converter is necessary

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
@@ -61,6 +61,13 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
   @Override
 	public boolean roomConnect(IConnection conn, Object[] params) {
 		log.info("BBB Video roomConnect"); 
+
+		if(params.length == 0) {
+			params = new Object[2];
+			params[0] = "UNKNOWN-MEETING-ID";
+			params[1] = "UNKNOWN-USER-ID";
+		}
+
   	String meetingId = ((String) params[0]).toString();
   	String userId = ((String) params[1]).toString();
   	

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/FFmpegCommand.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/FFmpegCommand.java
@@ -1,0 +1,124 @@
+package org.bigbluebutton.app.video.h263;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Iterator;
+
+public class FFmpegCommand {
+    private HashMap args;
+    private HashMap x264Params;
+
+    private String[] command;
+    
+    private String ffmpegPath;
+    private String input;
+    private String output;
+
+    public FFmpegCommand() {
+        this.args = new HashMap();
+        this.x264Params = new HashMap();
+
+        this.ffmpegPath = null;
+    }
+
+    public String[] getFFmpegCommand(boolean shouldBuild) {
+        if(shouldBuild)
+            buildFFmpegCommand();
+        
+        return this.command;
+    }
+
+    public void buildFFmpegCommand() {
+        List comm = new ArrayList<String>();
+
+        if(this.ffmpegPath == null)
+            this.ffmpegPath = "/usr/local/bin/ffmpeg";
+
+        comm.add(this.ffmpegPath);
+
+        comm.add("-i");
+        comm.add(input);
+
+        Iterator argsIter = this.args.entrySet().iterator();
+        while (argsIter.hasNext()) {
+            Map.Entry pairs = (Map.Entry)argsIter.next();
+            comm.add(pairs.getKey());
+            comm.add(pairs.getValue());
+        }
+
+        if(!x264Params.isEmpty()) {
+            comm.add("-x264-params");
+            String params = "";
+            Iterator x264Iter = this.x264Params.entrySet().iterator();
+            while (x264Iter.hasNext()) {
+                Map.Entry pairs = (Map.Entry)x264Iter.next();
+                String argValue = pairs.getKey() + "=" + pairs.getValue();
+                params += argValue;
+                // x264-params are separated by ':'
+                params += ":";
+            }
+            // Remove trailing ':'
+            params.replaceAll(":+$", "");
+            comm.add(params);
+        }
+
+        comm.add(this.output);
+
+        this.command = new String[comm.size()];
+        comm.toArray(this.command);
+    }
+
+    public void setFFmpegPath(String arg) {
+        this.ffmpegPath = arg;
+    }
+
+    public void setInput(String arg) {
+        this.input = arg;
+    }
+
+    public void setOutput(String arg) {
+        this.output = arg;
+    }
+
+    public void setCodec(String arg) {
+        this.args.put("-vcodec", arg);
+    }
+
+    public void setLevel(String arg) {
+        this.args.put("-level", arg);
+    }
+
+    public void setPreset(String arg) {
+        this.args.put("-preset", arg);
+    }
+
+    public void setProfile(String arg) {
+        this.args.put("-profile:v", arg);
+    }
+
+    public void setFormat(String arg) {
+        this.args.put("-f", arg);
+    }
+
+    public void setPayloadType(String arg) {
+        this.args.put("-payload_type", arg);
+    }
+
+    public void setLoglevel(String arg) {
+        this.args.put("-loglevel", arg);
+    }
+
+    public void setSliceMaxSize(String arg) {
+        this.x264Params.put("slice-max-size", arg);
+    }
+
+    public void setMaxKeyFrameInterval(String arg) {
+        this.x264Params.put("keyint", arg);
+    }
+    
+    public void setResolution(String arg) {
+        this.args.put("-s", arg);
+    }
+}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/H263Converter.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/H263Converter.java
@@ -1,0 +1,101 @@
+package org.bigbluebutton.app.video.h263;
+
+import org.red5.logging.Red5LoggerFactory;
+import org.red5.server.api.IConnection;
+import org.red5.server.api.Red5;
+import org.slf4j.Logger;
+
+/**
+ * Represents a stream converter to H263. This class is responsible
+ * for managing the execution of FFmpeg based on the number of listeners
+ * connected to the stream. When the first listener is added FFmpef is
+ * launched, and when the last listener is removed FFmpeg is stopped.
+ * Converted streams are published in the same scope as the original ones,
+ * with 'h263/' appended in the beginning.
+ */
+public class H263Converter {
+
+	private static Logger log = Red5LoggerFactory.getLogger(H263Converter.class, "video");
+
+	public final static String H263PREFIX = "h263/";
+
+	private String origin;
+	private Integer numListeners = 0;
+
+	FFmpegCommand ffmpeg;
+	ProcessMonitor processMonitor;
+	
+	/**
+	 * Creates a H263Converter from a given streamName. It is assumed
+	 * that one listener is responsible for this creation, therefore
+	 * FFmpeg is launched.
+	 * 
+	 * @param origin streamName of the stream that should be converted
+	 */
+	public H263Converter(String origin) {
+		log.info("Spawn FFMpeg to convert H264 to H263 for stream [{}]", origin);
+		this.origin = origin;
+		IConnection conn = Red5.getConnectionLocal();
+		String ip = conn.getHost();
+		String conf = conn.getScope().getName();
+		String inputLive = "rtmp://" + ip + "/video/" + conf + "/" + origin + " live=1";
+
+		String output = "rtmp://" + ip + "/video/" + conf + "/" + H263PREFIX + origin;
+
+		ffmpeg = new FFmpegCommand();
+		ffmpeg.setFFmpegPath("/usr/local/bin/ffmpeg");
+		ffmpeg.setInput(inputLive);
+		ffmpeg.setCodec("flv1"); // Sorensen H263
+		ffmpeg.setFormat("flv");
+		ffmpeg.setOutput(output);
+
+		this.addListener();
+	}
+
+	/**
+	 * Launches the process monitor responsible for FFmpeg.
+	 */
+	private void startConverter() {
+		String[] command = ffmpeg.getFFmpegCommand(true);
+		processMonitor = new ProcessMonitor(command);
+		processMonitor.start();
+	}
+
+	/**
+	 * Adds a listener to H263Converter. If there were
+	 * zero listeners, FFmpeg is launched for this stream.
+	 */
+	public synchronized void addListener() {
+		this.numListeners++;
+
+		if(this.numListeners.equals(1)) {
+			log.debug("First listener just joined, must start H263Converter for [{}]", origin);
+			startConverter();
+		}
+	}
+
+	/**
+	 * Removes a listener from H263Converter. There are
+	 * zero listeners left, FFmpeg is stopped this stream.
+	 */
+	public synchronized void removeListener() {
+		this.numListeners--;
+
+		if(this.numListeners <= 0) {
+			log.debug("No more listeners, may close H263Converter for [{}]", origin);
+			this.stopConverter();
+		}
+	}
+
+	/**
+	 * Stops FFmpeg for this stream and sets the number of
+	 * listeners to zero.
+	 */
+	public synchronized void stopConverter() {
+		this.numListeners = 0;
+		if(processMonitor != null) {
+			processMonitor.destroy();
+			processMonitor = null;
+		}
+	}
+}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/H263Converter.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/H263Converter.java
@@ -48,6 +48,7 @@ public class H263Converter {
 		ffmpeg.setCodec("flv1"); // Sorensen H263
 		ffmpeg.setFormat("flv");
 		ffmpeg.setOutput(output);
+		ffmpeg.setLoglevel("warning");
 
 		this.addListener();
 	}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/H263Converter.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/H263Converter.java
@@ -67,6 +67,7 @@ public class H263Converter {
 	 */
 	public synchronized void addListener() {
 		this.numListeners++;
+		log.trace("Adding listener to [{}] ; [{}] current listeners ", origin, this.numListeners);
 
 		if(this.numListeners.equals(1)) {
 			log.debug("First listener just joined, must start H263Converter for [{}]", origin);
@@ -80,6 +81,7 @@ public class H263Converter {
 	 */
 	public synchronized void removeListener() {
 		this.numListeners--;
+		log.trace("Removing listener from [{}] ; [{}] current listeners ", origin, this.numListeners);
 
 		if(this.numListeners <= 0) {
 			log.debug("No more listeners, may close H263Converter for [{}]", origin);

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/ProcessMonitor.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/ProcessMonitor.java
@@ -1,0 +1,105 @@
+package org.bigbluebutton.app.video.h263;
+
+import java.io.InputStream;
+
+import org.slf4j.Logger;
+import org.red5.logging.Red5LoggerFactory;
+
+import java.io.IOException;
+
+public class ProcessMonitor implements Runnable {
+    private static Logger log = Red5LoggerFactory.getLogger(ProcessMonitor.class, "video");
+
+    private String[] command;
+    private Process process;
+
+    ProcessStream inputStreamMonitor;
+    ProcessStream errorStreamMonitor;
+
+    private Thread thread = null;
+
+    public ProcessMonitor(String[] command) {
+        this.command = command;
+        this.process = null;
+        this.inputStreamMonitor = null;
+        this.errorStreamMonitor = null;
+    }
+    
+    public String toString() {
+        if (this.command == null || this.command.length == 0) { 
+            return "";
+        }
+        
+        StringBuffer result = new StringBuffer();
+        String delim = "";
+        for (String i : this.command) {
+        	result.append(delim).append(i);
+            delim = " ";
+        }
+        return result.toString();
+    }
+
+    public void run() {
+        try {
+            log.debug("Creating thread to execute FFmpeg");
+            log.debug("Executing: " + this.toString());
+            this.process = Runtime.getRuntime().exec(this.command);
+
+            if(this.process == null) {
+                log.debug("process is null");
+                return;
+            }
+
+            InputStream is = this.process.getInputStream();
+            InputStream es = this.process.getErrorStream();
+
+            inputStreamMonitor = new ProcessStream(is);
+            errorStreamMonitor = new ProcessStream(es);
+
+            inputStreamMonitor.start();
+            errorStreamMonitor.start();
+
+            this.process.waitFor();
+
+            int ret = this.process.exitValue();
+            log.debug("Exit value: " + ret);
+
+            destroy();
+        }
+        catch(SecurityException se) {
+            log.debug("Security Exception");
+        }
+        catch(IOException ioe) {
+            log.debug("IO Exception");
+        }
+        catch(NullPointerException npe) {
+            log.debug("NullPointer Exception");
+        }
+        catch(IllegalArgumentException iae) {
+            log.debug("IllegalArgument Exception");
+        }
+        catch(InterruptedException ie) {
+            log.debug("Interrupted Excetion");
+        }
+
+        log.debug("Exiting thread that executes FFmpeg");
+    }
+
+    public void start() {
+        this.thread = new Thread(this);
+        this.thread.start();
+    }
+
+    public void destroy() {
+        if(this.inputStreamMonitor != null 
+            && this.errorStreamMonitor != null) {
+            this.inputStreamMonitor.close();
+            this.errorStreamMonitor.close();
+        }
+
+        if(this.process != null) {
+            log.debug("Closing FFmpeg process");
+            this.process.destroy();
+        }
+    }
+}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/ProcessStream.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/ProcessStream.java
@@ -1,0 +1,59 @@
+package org.bigbluebutton.app.video.h263;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.slf4j.Logger;
+import org.red5.logging.Red5LoggerFactory;
+
+import java.io.IOException;
+
+public class ProcessStream implements Runnable {
+    private static Logger log = Red5LoggerFactory.getLogger(ProcessStream.class, "sip");
+    private InputStream stream;
+    private Thread thread;
+
+    ProcessStream(InputStream stream) {
+        if(stream != null)
+            this.stream = stream;
+    }
+
+    public void run() {
+        try {
+            log.debug("Creating thread to execute the process stream");
+            String line;
+            InputStreamReader isr = new InputStreamReader(this.stream);
+            BufferedReader ibr = new BufferedReader(isr);
+            while ((line = ibr.readLine()) != null) {
+                log.debug(line);
+            }
+
+            close();
+        }
+        catch(IOException ioe) {
+            log.debug("IOException");
+            close();
+        }
+
+        log.debug("Exiting thread that handles process stream");
+    }
+
+    public void start() {
+        this.thread = new Thread(this);
+        this.thread.start();
+    }
+
+    public void close() {
+        try {
+            if(this.stream != null) {
+                log.debug("Closing process stream");
+                this.stream.close();
+                this.stream = null;
+            }
+        }
+        catch(IOException ioe) {
+            log.debug("IOException");
+        }
+    }
+}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/ProcessStream.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/ProcessStream.java
@@ -10,7 +10,7 @@ import org.red5.logging.Red5LoggerFactory;
 import java.io.IOException;
 
 public class ProcessStream implements Runnable {
-    private static Logger log = Red5LoggerFactory.getLogger(ProcessStream.class, "sip");
+    private static Logger log = Red5LoggerFactory.getLogger(ProcessStream.class, "video");
     private InputStream stream;
     private Thread thread;
 


### PR DESCRIPTION
Include support in bbb-video to convert video streams to H263 (Sorenson), so the video stream may be played on iPads.

The streams are converted on demand, when at least one user requests it. The video is converted using FFmpeg thus, **FFmpeg must be compiled with librtmp** (--enable-librtmp).

To request a stream in H263 format the client must append "h263/" to the beginning of the stream name used to play.

There are approximatelly 7 seconds between when FFmpeg launches and  when the client start receiving video. Once running, the convertion delay is negligible.
