### PR TITLE
Video rotation and FFmpeg startup delay reduction

### DIFF
--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.bigbluebutton.app.video.converter.H263Converter;
+import org.bigbluebutton.app.video.converter.VideoRotator;
 import org.red5.logging.Red5LoggerFactory;
 import org.red5.server.adapter.MultiThreadedApplicationAdapter;
 import org.red5.server.api.IConnection;
@@ -48,6 +49,8 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
 	private final Map<String, IStreamListener> streamListeners = new HashMap<String, IStreamListener>();
 
 	private final Map<String, H263Converter> h263Converters = new HashMap<String, H263Converter>();
+
+	private final Map<String, VideoRotator> videoRotators = new HashMap<String, VideoRotator>();
 
     @Override
 	public boolean appStart(IScope app) {
@@ -179,14 +182,21 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
     public void streamBroadcastStart(IBroadcastStream stream) {
     	IConnection conn = Red5.getConnectionLocal();  
     	super.streamBroadcastStart(stream);
-    	log.info("streamBroadcastStart " + stream.getPublishedName() + " " + System.currentTimeMillis() + " " + conn.getScope().getName());
+    	String streamName = stream.getPublishedName();
+    	log.info("streamBroadcastStart " + streamName + " " + System.currentTimeMillis() + " " + conn.getScope().getName());
 
-        if (recordVideoStream && stream.getPublishedName().contains("/") == false) {
+        if (streamName.contains("/")) {
+            if(VideoRotator.getDirection(streamName) != null) {
+                VideoRotator rotator = new VideoRotator(streamName);
+                videoRotators.put(streamName, rotator);
+            }
+        }
+        else if (recordVideoStream) {
 	    	recordStream(stream);
 	    	VideoStreamListener listener = new VideoStreamListener(); 
 	        listener.setEventRecordingService(recordingService);
 	        stream.addStreamListener(listener); 
-	        streamListeners.put(conn.getScope().getName() + "-" + stream.getPublishedName(), listener);
+	        streamListeners.put(conn.getScope().getName() + "-" + streamName, listener);
         }
     }
 
@@ -271,9 +281,15 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
         recordingService.record(scopeName, event);    		
       }
 
-		if(h263Converters.containsKey(stream.getName())) {
+		String streamName = stream.getName();
+		if(h263Converters.containsKey(streamName)) {
 			// Stop converter
-			h263Converters.remove(stream.getName()).stopConverter();
+			h263Converters.remove(streamName).stopConverter();
+		}
+
+		if(videoRotators.containsKey(streamName)) {
+			// Stop rotator
+			videoRotators.remove(streamName).stop();
 		}
     }
     

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.bigbluebutton.app.video.h263.H263Converter;
+import org.bigbluebutton.app.video.converter.H263Converter;
 import org.red5.logging.Red5LoggerFactory;
 import org.red5.server.adapter.MultiThreadedApplicationAdapter;
 import org.red5.server.api.IConnection;

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/H263Converter.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/H263Converter.java
@@ -1,5 +1,7 @@
-package org.bigbluebutton.app.video.h263;
+package org.bigbluebutton.app.video.converter;
 
+import org.bigbluebutton.app.video.ffmpeg.FFmpegCommand;
+import org.bigbluebutton.app.video.ffmpeg.ProcessMonitor;
 import org.red5.logging.Red5LoggerFactory;
 import org.red5.server.api.IConnection;
 import org.red5.server.api.Red5;
@@ -22,8 +24,8 @@ public class H263Converter {
 	private String origin;
 	private Integer numListeners = 0;
 
-	FFmpegCommand ffmpeg;
-	ProcessMonitor processMonitor;
+	private FFmpegCommand ffmpeg;
+	private ProcessMonitor processMonitor;
 	
 	/**
 	 * Creates a H263Converter from a given streamName. It is assumed

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/H263Converter.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/H263Converter.java
@@ -51,6 +51,7 @@ public class H263Converter {
 		ffmpeg.setFormat("flv");
 		ffmpeg.setOutput(output);
 		ffmpeg.setLoglevel("warning");
+		ffmpeg.setAnalyzeDuration("10000"); // 10ms
 
 		this.addListener();
 	}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/VideoRotator.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/VideoRotator.java
@@ -51,6 +51,7 @@ public class VideoRotator {
 		ffmpeg.setOutput(output);
 		ffmpeg.setLoglevel("warning");
 		ffmpeg.setRotation(direction);
+		ffmpeg.setAnalyzeDuration("10000"); // 10ms
 
 		start();
 	}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/VideoRotator.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/converter/VideoRotator.java
@@ -1,0 +1,110 @@
+package org.bigbluebutton.app.video.converter;
+
+import org.bigbluebutton.app.video.ffmpeg.FFmpegCommand;
+import org.bigbluebutton.app.video.ffmpeg.ProcessMonitor;
+import org.red5.logging.Red5LoggerFactory;
+import org.red5.server.api.IConnection;
+import org.red5.server.api.Red5;
+import org.slf4j.Logger;
+
+/**
+ * Represents a stream rotator. This class is responsible
+ * for choosing the rotate direction based on the stream name
+ * and starting FFmpeg to rotate and re-publish the stream.
+ */
+public class VideoRotator {
+
+	private static Logger log = Red5LoggerFactory.getLogger(VideoRotator.class, "video");
+
+	public static final String ROTATE_LEFT = "rotate_left";
+	public static final String ROTATE_RIGHT = "rotate_right";
+
+	private String streamName;
+	private FFmpegCommand.ROTATE direction;
+
+	private FFmpegCommand ffmpeg;
+	private ProcessMonitor processMonitor;
+
+	/**
+	 * Create a new video rotator for the specified stream.
+	 * The streamName should be of the form: 
+	 * rotate_[left|right]/streamName
+	 * The rotated stream will be published as streamName.
+	 * 
+	 * @param origin Name of the stream that will be rotated
+	 */
+	public VideoRotator(String origin) {
+		this.streamName = getStreamName(origin);
+		this.direction = getDirection(origin);
+
+		IConnection conn = Red5.getConnectionLocal();
+		String ip = conn.getHost();
+		String conf = conn.getScope().getName();
+		String inputLive = "rtmp://" + ip + "/video/" + conf + "/" + origin + " live=1";
+
+		String output = "rtmp://" + ip + "/video/" + conf + "/" + streamName;
+
+		ffmpeg = new FFmpegCommand();
+		ffmpeg.setFFmpegPath("/usr/local/bin/ffmpeg");
+		ffmpeg.setInput(inputLive);
+		ffmpeg.setFormat("flv");
+		ffmpeg.setOutput(output);
+		ffmpeg.setLoglevel("warning");
+		ffmpeg.setRotation(direction);
+
+		start();
+	}
+	
+	/**
+	 * Get the stream name from the direction/streamName string
+	 * @param streamName Name of the stream with rotate direction
+	 * @return The stream name used for re-publish
+	 */
+	private String getStreamName(String streamName) {
+		String parts[] = streamName.split("/");
+		if(parts.length > 1)
+			return parts[1];
+		return "";
+	}
+
+	/**
+	 * Get the rotate direction from the streamName string.
+	 * @param streamName Name of the stream with rotate direction
+	 * @return FFmpegCommand.ROTATE for the given direction if present, null otherwise
+	 */
+	public static FFmpegCommand.ROTATE getDirection(String streamName) {
+		String parts[] = streamName.split("/");
+		
+		switch(parts[0]) {
+			case ROTATE_LEFT:
+				return FFmpegCommand.ROTATE.LEFT;
+			case ROTATE_RIGHT:
+				return FFmpegCommand.ROTATE.RIGHT;
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Start FFmpeg process to rotate and re-publish the stream.
+	 */
+	public void start() {
+		log.debug("Spawn FFMpeg to rotate [{}] stream [{}]", direction.name(), streamName);
+		String[] command = ffmpeg.getFFmpegCommand(true);
+		if (processMonitor == null) {
+			processMonitor = new ProcessMonitor(command);
+		}
+		processMonitor.start();
+	}
+
+	/**
+	 * Stop FFmpeg process that is rotating and re-publishing the stream.
+	 */
+	public void stop() {
+		log.debug("Stopping FFMpeg from rotate [{}] stream [{}]", direction.name(), streamName);
+		if(processMonitor != null) {
+			processMonitor.destroy();
+			processMonitor = null;
+		}
+	}
+}

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/FFmpegCommand.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/FFmpegCommand.java
@@ -1,4 +1,4 @@
-package org.bigbluebutton.app.video.h263;
+package org.bigbluebutton.app.video.ffmpeg;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/FFmpegCommand.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/FFmpegCommand.java
@@ -1,5 +1,6 @@
 package org.bigbluebutton.app.video.ffmpeg;
 
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,14 @@ public class FFmpegCommand {
     public FFmpegCommand() {
         this.args = new HashMap();
         this.x264Params = new HashMap();
+
+        /* Prevent quality loss by default */
+        try {
+            this.setVideoQualityScale(1);
+        } catch (InvalidParameterException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        };
 
         this.ffmpegPath = null;
     }
@@ -161,5 +170,22 @@ public class FFmpegCommand {
      */
     public void setAnalyzeDuration(String duration) {
         this.analyzeDuration = duration;
+    }
+
+    /**
+     * Set video quality scale to a value (1-31).
+     * 1 is the highest quality and 31 the lowest.
+     * <p>
+     * <b> Note: Does NOT apply to h264 encoder. </b>
+     * </p>
+     *
+     * @param scale Scale value (1-31)
+     * @throws InvalidParameterException
+     */
+    public void setVideoQualityScale(Integer scale) throws InvalidParameterException {
+        if(scale < 1 || scale > 31)
+            throw new InvalidParameterException("Scale must be a value in 1-31 range");
+
+        this.args.put("-q:v", scale.toString());
     }
 }

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/FFmpegCommand.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/FFmpegCommand.java
@@ -22,6 +22,9 @@ public class FFmpegCommand {
     private String input;
     private String output;
 
+    /* Analyze duration is a special parameter that MUST come before the input */
+    private String analyzeDuration;
+
     public FFmpegCommand() {
         this.args = new HashMap();
         this.x264Params = new HashMap();
@@ -43,6 +46,12 @@ public class FFmpegCommand {
             this.ffmpegPath = "/usr/local/bin/ffmpeg";
 
         comm.add(this.ffmpegPath);
+
+        /* Analyze duration MUST come before the input */
+        if(analyzeDuration != null && !analyzeDuration.isEmpty()) {
+            comm.add("-analyzeduration");
+            comm.add(analyzeDuration);
+        }
 
         comm.add("-i");
         comm.add(input);
@@ -141,5 +150,16 @@ public class FFmpegCommand {
                 this.args.put("-vf", "transpose=1");
                 break;
         }
+    }
+
+    /**
+     * Set how much time FFmpeg should  analyze stream
+     * data to get stream information. Note that this
+     * affects directly the delay to start the stream.
+     *
+     * @param duration Rotate direction
+     */
+    public void setAnalyzeDuration(String duration) {
+        this.analyzeDuration = duration;
     }
 }

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/ProcessMonitor.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/ProcessMonitor.java
@@ -1,4 +1,4 @@
-package org.bigbluebutton.app.video.h263;
+package org.bigbluebutton.app.video.ffmpeg;
 
 import java.io.InputStream;
 

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/ProcessStream.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/ffmpeg/ProcessStream.java
@@ -1,4 +1,4 @@
-package org.bigbluebutton.app.video.h263;
+package org.bigbluebutton.app.video.ffmpeg;
 
 import java.io.BufferedReader;
 import java.io.InputStream;

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/FFmpegCommand.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/h263/FFmpegCommand.java
@@ -7,6 +7,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 public class FFmpegCommand {
+
+    /**
+     * Indicate the direction to rotate the video
+     */
+    public enum ROTATE { LEFT, RIGHT };
+
     private HashMap args;
     private HashMap x264Params;
 
@@ -120,5 +126,20 @@ public class FFmpegCommand {
     
     public void setResolution(String arg) {
         this.args.put("-s", arg);
+    }
+
+    /**
+     * Set the direction to rotate the video
+     * @param arg Rotate direction
+     */
+    public void setRotation(ROTATE arg) {
+        switch (arg) {
+            case LEFT:
+                this.args.put("-vf", "transpose=2");
+                break;
+            case RIGHT:
+                this.args.put("-vf", "transpose=1");
+                break;
+        }
     }
 }


### PR DESCRIPTION
- Mechanism to rotate video streams.
  - Streams to be rotated should be published with a stream name begining with `rotate_left/` or `rotate_right/`
- FFmpeg startup delay reduction.
  - Reduced the maximum analyze duration from 5 seconds (default) to 10 milliseconds.
