### PR TITLE
Fixed locker icon appearing issue when a locked user is promoted to moderator.

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -214,6 +214,12 @@
 						lockImg.includeInLayout = !rolledOver;
 						lockBtn.visible = rolledOver;
 						lockBtn.includeInLayout = rolledOver;
+					} else if ( data.role == BBBUser.MODERATOR ){
+						//If it can't be clicked, only show image
+						lockImg.visible = false;
+						lockImg.includeInLayout = false;
+						lockBtn.visible = false;
+						lockBtn.includeInLayout = false;
 					} else {
 						//If it can't be clicked, only show image
 						lockImg.visible = true;
@@ -221,6 +227,7 @@
 						lockBtn.visible = false;
 						lockBtn.includeInLayout = false;
 					}
+
 					
 					if (data.hasStream) {
 						// if it's myself or if I'm watching all the streams from the given user, then don't activate the button


### PR DESCRIPTION
When a locked viewer is promoted to moderator the locker icon will now be removed.

The locker settings are kept for the user (his locker settings are restored once he is demoted).
 #ref 1744
