### PR TITLE
Fixed empty sharednotes when connecting problem.

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/Constants.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/Constants.scala
@@ -105,4 +105,5 @@ object Constants {
   val NOTES = "notes"
   val NOTE_NAME = "note_name"
   val PATCH = "patch"
+  val PATCH_ID = "patch_id"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
@@ -137,7 +137,7 @@ case class GuestPolicyChanged(meetingID: String, recorded: Boolean, policy: Stri
 case class GuestAccessDenied(meetingID: String, recorded: Boolean, userId: String) extends IOutMessage
 
 // Shared Notes
-case class PatchDocumentReply(meetingID: String, recorded: Boolean, requesterID: String, noteID: String, patch: String) extends IOutMessage
+case class PatchDocumentReply(meetingID: String, recorded: Boolean, requesterID: String, noteID: String, patch: String, patchID: Int) extends IOutMessage
 case class GetCurrentDocumentReply(meetingID: String, recorded: Boolean, requesterID: String, notes: Map[String, Note]) extends IOutMessage
 case class CreateAdditionalNotesReply(meetingID: String, recorded: Boolean, requesterID: String, noteID: String, noteName: String) extends IOutMessage
 case class DestroyAdditionalNotesReply(meetingID: String, recorded: Boolean, requesterID: String, noteID: String) extends IOutMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/ValueObjects.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/ValueObjects.scala
@@ -145,4 +145,5 @@ case class MeetingInfo(meetingID: String, meetingName: String, recorded: Boolean
 
 case class Note(
   name: String,
-  document: String)
+  document: String,
+  patchCounter: Int)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/SharedNotesApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/SharedNotesApp.scala
@@ -10,9 +10,9 @@ trait SharedNotesApp {
   val outGW: OutMessageGateway
 
   def handlePatchDocumentRequest(msg: PatchDocumentRequest) {
-    notesModel.patchDocument(msg.noteID, msg.patch)
+    val patchID = notesModel.patchDocument(msg.noteID, msg.patch)
 
-    outGW.send(new PatchDocumentReply(mProps.meetingID, mProps.recorded, msg.requesterID, msg.noteID, msg.patch))
+    outGW.send(new PatchDocumentReply(mProps.meetingID, mProps.recorded, msg.requesterID, msg.noteID, msg.patch, patchID))
   }
 
   def handleGetCurrentDocumentRequest(msg: GetCurrentDocumentRequest) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/SharedNotesModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/SharedNotesModel.scala
@@ -9,18 +9,20 @@ import java.util.Collections
 
 class SharedNotesModel {
   val notes = new scala.collection.mutable.HashMap[String, Note]()
-  notes += ("MAIN_WINDOW" -> new Note("", ""))
+  notes += ("MAIN_WINDOW" -> new Note("", "", 0))
   private val patcher = new diff_match_patch()
   private var notesCounter = 0;
   private var removedNotes: Set[Int] = Set()
 
-  def patchDocument(noteID: String, patch: String) {
+  def patchDocument(noteID: String, patch: String): Integer = {
     notes.synchronized {
       val note = notes(noteID)
       val document = note.document
       val patchObjects = patcher.patch_fromText(patch)
       val result = patcher.patch_apply(patchObjects, document)
-      notes(noteID) = new Note(note.name, result(0).toString())
+      val patchCounter = note.patchCounter + 1
+      notes(noteID) = new Note(note.name, result(0).toString(), patchCounter)
+      patchCounter
     }
   }
 
@@ -33,7 +35,7 @@ class SharedNotesModel {
       noteID = removedNotes.min
       removedNotes -= noteID
     }
-    notes += (noteID.toString -> new Note(noteName, ""))
+    notes += (noteID.toString -> new Note(noteName, "", 0))
 
     noteID.toString
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/SharedNotesMessageToJsonConverter.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/SharedNotesMessageToJsonConverter.scala
@@ -13,6 +13,7 @@ object SharedNotesMessageToJsonConverter {
     payload.put(Constants.REQUESTER_ID, msg.requesterID)
     payload.put(Constants.NOTE_ID, msg.noteID)
     payload.put(Constants.PATCH, msg.patch)
+    payload.put(Constants.PATCH_ID, msg.patchID)
 
     val header = Util.buildHeader(MessageNames.PATCH_DOCUMENT_REPLY, None)
     Util.buildJson(header, payload)

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Constants.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Constants.java
@@ -131,6 +131,7 @@ public class Constants {
   public static final String GUEST_POLICY                    = "guest_policy";
   public static final String NOTE_ID                         = "note_id";
   public static final String PATCH                           = "patch";
+  public static final String PATCH_ID                        = "patch_id";
   public static final String NOTE_NAME                       = "note_name";
   public static final String NOTES                           = "notes";
   public static final String ADDITIONAL_NOTES_SET_SIZE       = "additional_notes_set_size";

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/PatchDocumentReplyMessage.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/PatchDocumentReplyMessage.java
@@ -16,12 +16,14 @@ public class PatchDocumentReplyMessage implements ISubscribedMessage {
 	public final String requesterID;
 	public final String noteID;
 	public final String patch;
+	public final Integer patchID;
 
-	public PatchDocumentReplyMessage(String meetingID, String requesterID, String noteID, String patch) {
+	public PatchDocumentReplyMessage(String meetingID, String requesterID, String noteID, String patch, Integer patchID) {
 		this.meetingID = meetingID;
 		this.requesterID = requesterID;
 		this.noteID = noteID;
 		this.patch = patch;
+		this.patchID = patchID;
 	}
 
 	public String toJson() {
@@ -30,6 +32,7 @@ public class PatchDocumentReplyMessage implements ISubscribedMessage {
 		payload.put(Constants.REQUESTER_ID, requesterID);
 		payload.put(Constants.NOTE_ID, noteID);
 		payload.put(Constants.PATCH, patch);
+		payload.put(Constants.PATCH_ID, patchID);
 
 		java.util.HashMap<String, Object> header = MessageBuilder.buildHeader(PATCH_DOCUMENT_REPLY, VERSION, null);
 
@@ -50,13 +53,15 @@ public class PatchDocumentReplyMessage implements ISubscribedMessage {
 					if (payload.has(Constants.MEETING_ID)
 							&& payload.has(Constants.REQUESTER_ID)
 							&& payload.has(Constants.NOTE_ID)
-							&& payload.has(Constants.PATCH)) {
+							&& payload.has(Constants.PATCH)
+							&& payload.has(Constants.PATCH_ID)) {
 						String meetingID = payload.get(Constants.MEETING_ID).getAsString();
 						String requesterID = payload.get(Constants.REQUESTER_ID).getAsString();
 						String noteID = payload.get(Constants.NOTE_ID).getAsString();
 						String patch = payload.get(Constants.PATCH).getAsString();
+						Integer patchID = payload.get(Constants.PATCH_ID).getAsInt();
 
-						return new PatchDocumentReplyMessage(meetingID, requesterID, noteID, patch);
+						return new PatchDocumentReplyMessage(meetingID, requesterID, noteID, patch, patchID);
 					}
 				}
 			}

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Util.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Util.java
@@ -682,10 +682,12 @@ public class Util {
 	class Note {
 		String name = "";
 		String document = "";
+		Integer patchCounter = 0;
 
-		public Note(String name, String document) {
+		public Note(String name, String document, Integer patchCounter) {
 			this.name = name;
 			this.document = document;
+			this.patchCounter = patchCounter;
 		}
 	}
 
@@ -696,7 +698,8 @@ public class Util {
 			JsonObject obj = entry.getValue().getAsJsonObject();
 			String name = obj.get("name").getAsString();
 			String document = obj.get("document").getAsString();
-			Note note = new Note(name, document);
+			Integer patchCounter = obj.get("patchCounter").getAsInt();
+			Note note = new Note(name, document, patchCounter);
 			notesMap.put(entry.getKey(), (Object) note);
 		}
 

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/client/SharedNotesClientMessageSender.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/client/SharedNotesClientMessageSender.java
@@ -57,6 +57,7 @@ public class SharedNotesClientMessageSender {
 			args.put("userID", msg.requesterID);
 			args.put("noteID", msg.noteID);
 			args.put("patch", msg.patch);
+			args.put("patchID", msg.patchID);
 
 			Map<String, Object> message = new HashMap<String, Object>();
 			Gson gson = new Gson();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/events/ReceivePatchEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/events/ReceivePatchEvent.as
@@ -26,6 +26,7 @@ package org.bigbluebutton.modules.sharednotes.events
 		public static const RECEIVE_PATCH_EVENT:String = 'RECEIVE_PATCH_EVENT';
 		public var patch:String;
 		public var noteId:String;
+		public var patchId:Number;
 						
 		public function ReceivePatchEvent(type:String = RECEIVE_PATCH_EVENT, bubbles:Boolean=true, cancelable:Boolean=false)
 		{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -35,6 +35,8 @@
 
 	<mx:Script>
 		<![CDATA[
+			import org.as3commons.logging.api.ILogger;
+			import org.as3commons.logging.api.getClassLogger;
 			import com.asfusion.mate.events.Dispatcher;
 			
 			import flash.utils.getTimer;
@@ -65,9 +67,11 @@
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 			import flash.utils.getQualifiedClassName;
 			import mx.collections.ArrayCollection;
+			private static const LOGGER:ILogger = getClassLogger(SharedNotesWindow);
 
 			protected var _dispatcher:Dispatcher = new Dispatcher();
 			private var _document:String = "";
+			private var _lastPatch:Number = -1;
 			protected var _notesId:String="MAIN_WINDOW";
 			protected var _noteName:String = "";
 
@@ -149,6 +153,7 @@
 				var note:Object = notes[noteId];
 				_document = note["document"];
 				_noteName = note["name"];
+				_lastPatch = note["patchCounter"];
 				richTextEditor.htmlText = _document;
 				if (!this.enabled) this.enabled = true;
 				updateTitle();
@@ -171,13 +176,20 @@
 			private function receivePatch(e:ReceivePatchEvent):void {
 //				LOGGER.debug("SharedNotesWindow: patch received");
 //				LOGGER.debug("=====\n" + e.patch + "\n=====");
-				if (e.patch != "" && e.noteId==noteId) {
-					var result:String = DiffPatch.patch(e.patch, _document);
-//					LOGGER.debug("SharedNotesWindow: before the patch\n" + _document);
-//					LOGGER.debug("SharedNotesWindow: after the patch\n" + result);
-					_document = result;
-//					LOGGER.debug("SharedNotes: patching local with server modifications");
-					richTextEditor.patch(e.patch);
+				if (e.noteId == noteId) {
+					if (_lastPatch == (e.patchId - 1)) {
+						if (e.patch != "") {
+							var result:String = DiffPatch.patch(e.patch, _document);
+//							LOGGER.debug("SharedNotesWindow: before the patch\n" + _document);
+//							LOGGER.debug("SharedNotesWindow: after the patch\n" + result);
+							_document = result;
+//							LOGGER.debug("SharedNotes: patching local with server modifications");
+							richTextEditor.patch(e.patch);
+						}
+						_lastPatch = e.patchId;
+					} else {
+						LOGGER.error("Patch missmatch");
+					}
 				}
 			}
 


### PR DESCRIPTION
This should fix a rare bug that makes a user to lose sync of his notes when connecting while the server is receiving a high amount of patches of shared notes.
