### PR TITLE
Avoid opening the guest window for a promoted user when the guest list is empty

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/GuestManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/GuestManager.as
@@ -41,9 +41,11 @@ package org.bigbluebutton.main.model
 		}
 
 		public function refreshGuestView():void {
-			var refreshGuestEvent:RefreshGuestEvent = new RefreshGuestEvent();
-			refreshGuestEvent.listOfGuests = guest.getGuests();
-			dispatcher.dispatchEvent(refreshGuestEvent);
+			if (guest.hasGuest()) {
+				var refreshGuestEvent:RefreshGuestEvent = new RefreshGuestEvent();
+				refreshGuestEvent.listOfGuests = guest.getGuests();
+				dispatcher.dispatchEvent(refreshGuestEvent);
+			}
 		}
 
 		public function removeAllGuests():void {


### PR DESCRIPTION
This went missing when I made this changes to make sure a promoted user would open the waiting guest's window:
https://github.com/pedrobmarin/bigbluebutton/commit/c40684b13dfb3313a884d1d397bfd612af32b6dc
