### PR TITLE
Fixed shared notes get current document timer initialization

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -105,6 +105,12 @@
 				BindingUtils.bindSetter(updateRoleDependentProperties, UsersUtil.getMyself(), "role");
 
 				updateTitle();
+
+				if (noteId == "MAIN_WINDOW") {
+					this.enabled = false;
+					getDocumentTimer.addEventListener(TimerEvent.TIMER, checkCurrentDocument);
+					getDocumentTimer.start();
+				}
 			}
 
 			private function gotCurrentDocument():void {
@@ -137,9 +143,6 @@
 			private function updateRoleDependentProperties(role:String):void {
 				if(noteId == "MAIN_WINDOW"){
 					btnNew.visible = btnNew.includeInLayout = options.enableMultipleNotes && role == Role.MODERATOR;
-					this.enabled = false;
-					getDocumentTimer.addEventListener(TimerEvent.TIMER, checkCurrentDocument);
-					getDocumentTimer.start();
 				} else {
 					showCloseButton = role == Role.MODERATOR;
 				}


### PR DESCRIPTION
I think a conflict in a merge may have created this issue. Now we'll have the getCurrentDocument timer only triggered at the main note view creation.
