### PR TITLE
Fixed paricipant audio process at flash client

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -480,7 +480,7 @@ package org.bigbluebutton.modules.users.services
       var externUserID:String = webUser.externUserID;
       var internUserID:String = webUser.userId;
       
-      if (UsersUtil.getMyExternalUserID() == externUserID) {
+      if (UsersUtil.getMyUserID() == internUserID) {
         _conference.muteMyVoice(voiceUser.muted);
         _conference.setMyVoiceJoined(voiceUser.joined);
       }


### PR DESCRIPTION
Issue: A new user was being processed as a user that already joined audio.
Steps to reproduce: Enter a meeting and join webrtc audio; refresh the page and there is a chance the new user will keep the mic icon at the users view.
This problem was occurring because both users may have the same external user id and that was the test we were making when processing the voice user. Changed that to the internal user id.
