### PR TITLE
Microphone icon now gets a relative position over webcam video

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphicHolder.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphicHolder.mxml
@@ -323,9 +323,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                 </mx:Box>
             </mx:HBox>
             <mx:Box
-                    width="100%"
-                    paddingTop="15"
-                    paddingRight="15"
+                    width="95%"
+                    height="5%"
+                    verticalAlign="bottom"
                     horizontalAlign="right" >
                 <mx:Box
                         id="muteBtnWrapper"


### PR DESCRIPTION
I made it very simple. Mic icon will always display top right varying a bit as the video aspect changes.
