### PR TITLE
Removing timeline attribute for deskshare video

### DIFF
--- a/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
@@ -373,7 +373,6 @@ load_deskshare_video = function () {
    webmsource.setAttribute('type','video/webm; codecs="vp8.0, vorbis"');
    deskshare_video.appendChild(webmsource);
 
-   deskshare_video.setAttribute('data-timeline-sources', SLIDES_XML);
    var presentationArea = document.getElementById("presentation-area");
    presentationArea.insertBefore(deskshare_video,presentationArea.childNodes[0]);
 

--- a/record-and-playback/presentation_export/playback/presentation_export/playback.js
+++ b/record-and-playback/presentation_export/playback/presentation_export/playback.js
@@ -373,7 +373,6 @@ load_deskshare_video = function () {
    webmsource.setAttribute('type','video/webm; codecs="vp8.0, vorbis"');
    deskshare_video.appendChild(webmsource);
 
-   deskshare_video.setAttribute('data-timeline-sources', SLIDES_XML);
    var presentationArea = document.getElementById("presentation-area");
    presentationArea.insertBefore(deskshare_video,presentationArea.childNodes[0]);
 


### PR DESCRIPTION
We don't need it. This causes duplicate chat messages in recording playback.