### PR TITLE
Handling presentation tab change through keyboard shortcuts

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -81,6 +81,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import mx.events.MenuEvent;
 			import mx.events.ResizeEvent;
 			import mx.managers.PopUpManager;
+			import mx.controls.TabBar;
 			
 			import flexlib.mdi.events.MDIWindowEvent;
 			
@@ -848,6 +849,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					btnActualSize.visible = false;
 					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = true;
 					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = true;
+					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = true;
 				} else {
 					pollVoteBox.visible = false;
 					pollVoteBox.includeInLayout = false;
@@ -860,6 +862,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						btnClosePublish.visible = false;
 						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = false;
 						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = false;
+						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = false;
 					} else if (currentTabIndex == DESKSHARE_VIEW_TAB_INDEX) {
 						btnActualSize.visible = true;
 						downloadPres.visible = true;
@@ -932,7 +935,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function onSelectTabEvent(event:MouseEvent):void {
-				onSelectTab();
+				if (event.target.parent is TabBar) {
+					var selectedIndex:uint= TabBar(event.target.parent).getChildIndex(event.target as DisplayObject);
+					if(presenterTabs.getTabAt(selectedIndex).enabled) {
+					   presenterTabs.selectedIndex = selectedIndex;
+					   onSelectTab();
+					}
+				}
 			}
 
 			private function onSelectTab():void {
@@ -966,6 +975,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				if(!presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).visible) {
 					presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).visible = true;
 					presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).includeInLayout = true;
+					presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).enabled = true;
 				}
 
 				btnActualSize.visible = false;
@@ -976,6 +986,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				} else if(presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible) {
 					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = false;
 					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = false;
+					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = false;
 				}
 			}
 
@@ -1030,6 +1041,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				LOGGER.debug("Stopping desktop publish");
 				presenterTabs.getTabAt(DESKSHARE_VIEW_TAB_INDEX).visible = false;
 				presenterTabs.getTabAt(DESKSHARE_VIEW_TAB_INDEX).includeInLayout = false;
+				presenterTabs.getTabAt(DESKSHARE_VIEW_TAB_INDEX).enabled = false;
 				dispatchEvent(new ShareEvent(ShareEvent.STOP_SHARING));
 				sharing = false;
 				PresentationModel.getInstance().getCurrentPresentation().sharingDesktop = false;
@@ -1076,10 +1088,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						PresentationModel.getInstance().getCurrentPresentation().sharingDesktop = true;
 						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = false;
 						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = false;
+						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = false;
 					}
 					else {
 						presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).visible = false;
 						presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).includeInLayout = false;
+						presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).enabled = false;
 					}
 				} else {
 					LOGGER.debug("viewTabContent is NULL.");

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -402,7 +402,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function becomeViewer():void{
 				setupPresenter(false);
 				dispatchEvent(new UploadEvent(UploadEvent.CLOSE_UPLOAD_WINDOW));
-				this.customContextMenuItems = new Array();
+				removeContextMenuItems();
 				if (slideView.thumbnailView.visible)
 					showThumbnails();
 			}
@@ -478,6 +478,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				contextMenuItems.push(previousButton);
 								
 				this.customContextMenuItems = contextMenuItems;
+			}
+
+			private function removeContextMenuItems():void{
+				this.customContextMenuItems = new Array();
 			}
 			
 			private function notifyOthersOfSharingPresentation(presentationName:String):void {
@@ -592,7 +596,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				if(Capabilities.hasAccessibility)
 					Accessibility.updateProperties();
 
-				addContextMenuItems();
+				if(currentTabIndex == PRESENTATION_TAB_INDEX)
+					addContextMenuItems();
 				
 				updateDownloadBtnTooltip();
 				setPollMenuData();
@@ -617,42 +622,42 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function remoteUpload(e:ShortcutEvent):void{
-				if (uploadPres.visible){
+				if (uploadPres.visible && currentTabIndex == PRESENTATION_TAB_INDEX){
 					uploadPres.setFocus();
 					openUploadWindow();
 				}
 			}
 			
 			private function remotePrevious(e:ShortcutEvent):void{
-				if (backButton.visible && backButton.enabled){
+				if (backButton.visible && backButton.enabled && currentTabIndex == PRESENTATION_TAB_INDEX){
 					//backButton.setFocus();
 					gotoPreviousSlide();
 				}
 			}
 			
 			private function remoteSelect(e:ShortcutEvent):void{
-				if (btnSlideNum.visible){
+				if (btnSlideNum.visible && currentTabIndex == PRESENTATION_TAB_INDEX){
 					btnSlideNum.setFocus();
 					showThumbnails();
 				}
 			}
 			
 			private function remoteNext(e:ShortcutEvent):void{
-				if (forwardButton.visible && forwardButton.enabled){
+				if (forwardButton.visible && forwardButton.enabled && currentTabIndex == PRESENTATION_TAB_INDEX){
 					//forwardButton.setFocus();
 					gotoNextSlide();
 				}
 			}
 			
 			private function remoteWidth(e:ShortcutEvent):void{
-				if (btnFitToWidth.visible){
+				if (btnFitToWidth.visible && currentTabIndex == PRESENTATION_TAB_INDEX){
 					btnFitToWidth.setFocus();
 					onFitToPage(false);
 				}
 			}
 			
 			private function remotePage(e:ShortcutEvent):void{
-				if (btnFitToPage.visible){
+				if (btnFitToPage.visible && currentTabIndex == PRESENTATION_TAB_INDEX){
 					btnFitToPage.setFocus();
 					onFitToPage(true);
 				}
@@ -847,9 +852,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					pollVoteBox.includeInLayout = false;
 					btnClosePublish.visible = false;
 					btnActualSize.visible = false;
-					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = true;
-					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = true;
-					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = true;
+					enableTab(DESKSHARE_PUBLISH_TAB_INDEX,true);
 				} else {
 					pollVoteBox.visible = false;
 					pollVoteBox.includeInLayout = false;
@@ -860,9 +863,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						presenterControls.includeInLayout = false;
 						btnActualSize.visible = false;
 						btnClosePublish.visible = false;
-						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = false;
-						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = false;
-						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = false;
+						enableTab(DESKSHARE_PUBLISH_TAB_INDEX,false);
 					} else if (currentTabIndex == DESKSHARE_VIEW_TAB_INDEX) {
 						btnActualSize.visible = true;
 						downloadPres.visible = true;
@@ -871,6 +872,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				// Need to call the function later because the heights haven't been validated yet
 				callLater(fitSlideToWindowMaintainingAspectRatio);
+			}
+
+			private function enableTab(tabIndex:Number, enable:Boolean):void {
+				presenterTabs.getTabAt(tabIndex).visible = enable;
+				presenterTabs.getTabAt(tabIndex).includeInLayout = enable;
+				presenterTabs.getTabAt(tabIndex).enabled = enable;
 			}
 			
 			private function pollStoppedHandler(e:PollStoppedEvent):void {
@@ -973,9 +980,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				}
 
 				if(!presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).visible) {
-					presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).visible = true;
-					presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).includeInLayout = true;
-					presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).enabled = true;
+					enableTab(PRESENTATION_TAB_INDEX,true);
 				}
 
 				btnActualSize.visible = false;
@@ -983,10 +988,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				if (UsersUtil.amIPresenter()) {
 					setControlBarState("presenter");
 					annotationsPermissionChanged(true);
+					addContextMenuItems();
 				} else if(presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible) {
-					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = false;
-					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = false;
-					presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = false;
+					enableTab(DESKSHARE_PUBLISH_TAB_INDEX,false);
 				}
 			}
 
@@ -1001,6 +1005,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					pollStartBtn.visible = false;
 					annotationsPermissionChanged(false);
 				}
+
+				removeContextMenuItems();
 			}
 
 			private function handleDesktopViewTabSelected():void {
@@ -1028,6 +1034,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					pollStartBtn.visible = true;
 					btnClosePublish.visible = true;
 				}
+
+				removeContextMenuItems();
 			}
 
 			private function changeWhiteboardPageOnly(whiteboardId:String):void {
@@ -1039,9 +1047,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			private function stopSharing():void {
 				LOGGER.debug("Stopping desktop publish");
-				presenterTabs.getTabAt(DESKSHARE_VIEW_TAB_INDEX).visible = false;
-				presenterTabs.getTabAt(DESKSHARE_VIEW_TAB_INDEX).includeInLayout = false;
-				presenterTabs.getTabAt(DESKSHARE_VIEW_TAB_INDEX).enabled = false;
+				enableTab(DESKSHARE_VIEW_TAB_INDEX,false);
 				dispatchEvent(new ShareEvent(ShareEvent.STOP_SHARING));
 				sharing = false;
 				PresentationModel.getInstance().getCurrentPresentation().sharingDesktop = false;
@@ -1086,14 +1092,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					if (UsersUtil.amIPresenter()) {
 						sharing = true;
 						PresentationModel.getInstance().getCurrentPresentation().sharingDesktop = true;
-						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).visible = false;
-						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).includeInLayout = false;
-						presenterTabs.getTabAt(DESKSHARE_PUBLISH_TAB_INDEX).enabled = false;
+						enableTab(DESKSHARE_PUBLISH_TAB_INDEX,false);
 					}
 					else {
-						presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).visible = false;
-						presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).includeInLayout = false;
-						presenterTabs.getTabAt(PRESENTATION_TAB_INDEX).enabled = false;
+						enableTab(PRESENTATION_TAB_INDEX,false);
 					}
 				} else {
 					LOGGER.debug("viewTabContent is NULL.");


### PR DESCRIPTION
There were 2 issues:
- Flash was letting invisible tabs be accessed through keyboard shortcuts. We have to disable the invisible tabs as well.
- TabNavigator does not update the selectedIndex when the tab change is made through a keyboard shortcut. We have to get the correct index using TabBar and mouse event informations.