### PR TITLE
Avoid sending zoom events while typing in slide's textbox

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -952,16 +952,22 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function onSelectTab():void {
-				if (presenterTabs.selectedIndex != currentTabIndex) {
-					if(presenterTabs.selectedIndex == PRESENTATION_TAB_INDEX) {
+				if (presenterTabs.selectedIndex == currentTabIndex) return;
+
+				switch (presenterTabs.selectedIndex) {
+					case PRESENTATION_TAB_INDEX:
 						handlePresentationTabSelected();
-					} else if (presenterTabs.selectedIndex == DESKSHARE_PUBLISH_TAB_INDEX) {
+						break;
+					case DESKSHARE_PUBLISH_TAB_INDEX:
 						handleDesktopPublishTabSelected();
-					} else {
+						break;
+					case DESKSHARE_VIEW_TAB_INDEX:
 						handleDesktopViewTabSelected();
-					}
-					updateDownloadBtn();
+						break;
+					default:
+						break;
 				}
+				updateDownloadBtn();
 				callLater(fitSlideToWindowMaintainingAspectRatio);
 			}
 


### PR DESCRIPTION
This will fix #381. Although I believe we could use some refactor over this view. I suggest @alexandrekreis give a good look at this while we test in bbb-1.1 merge.