### PR TITLE
Removed old FreeSWITCH paths that we added in the beggining of versio…

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -78,15 +78,8 @@ SERVLET_DIR=/var/lib/$SERVLET_CONTAINER/webapps
 
 FREESWITCH_VARS=/opt/freeswitch/conf/vars.xml
 FREESWITCH_EXTERNAL=/opt/freeswitch/conf/sip_profiles/external.xml
-FREESWITCH_PID=/opt/freeswitch/run/freeswitch.pid
+FREESWITCH_PID=/opt/freeswitch/var/run/freeswitch/freeswitch.pid
 FREESWITCH_EVENT_SOCKET=/opt/freeswitch/conf/autoload_configs/event_socket.conf.xml
-
-if [ ! -d /opt/freeswitch/conf ]; then
-	FREESWITCH_VARS=/opt/freeswitch/etc/freeswitch/vars.xml
-	FREESWITCH_EXTERNAL=/opt/freeswitch/etc/freeswitch/sip_profiles/external.xml
-	FREESWITCH_PID=/opt/freeswitch/var/run/freeswitch/freeswitch.pid
-	FREESWITCH_EVENT_SOCKET=/opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
-fi
 
 if [ ! -f /usr/share/red5/webapps/bigbluebutton/WEB-INF/red5-web.xml ]; then
 	echo "#"


### PR DESCRIPTION
…n 1.6 testing

And probably we don't need any of those anymore since jenkins already created new packages for freeswitch that match this static path.