### PR TITLE
When skipping the camera settings check, we must use the camera index…

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
@@ -396,7 +396,7 @@ package org.bigbluebutton.modules.videoconf.maps
     public function handleShareCameraRequestEvent(event:ShareCameraRequestEvent):void {
 		LOGGER.debug("[VideoEventMapDelegate:handleShareCameraRequestEvent]");
 		if (options.skipCamSettingsCheck) {
-			skipCameraSettingsCheck();
+			skipCameraSettingsCheck(parseInt(event.defaultCamera));
 		} else {
 			openWebcamPreview(event.publishInClient, event.defaultCamera, event.camerasArray);
 		}


### PR DESCRIPTION
… information as well

Otherwise, we will always open the default camera...