### PR TITLE
Included in the metadata the externalId of the users that activated t…

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RecordingMetadata.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RecordingMetadata.java
@@ -18,6 +18,10 @@ public class RecordingMetadata {
    <published>true</published>
    <start_time>1489173065780</start_time>
    <end_time>1489173199386</end_time>
+   <recording_users>
+   <userExternalId>iuwhefjbksjdbubv</userExternalId>
+   <userExternalId>hjklhjklhjkl98ol</userExternalId>
+   </recording_users>
    <breakout parentMeetingId="f3ffe06acedf425565cc024c8ebe89a6552e8782-1489172964374" sequence="2" meetingId="f2041d123b6a4b994e7ad87ee9d348496a73472c-1489173065780"/>
    <meta>
    <meetingId>f2041d123b6a4b994e7ad87ee9d348496a73472c-1489173065780</meetingId>
@@ -65,6 +69,10 @@ public class RecordingMetadata {
 
   @JacksonXmlProperty(localName = "raw_size")
   private String rawSize;
+
+  @JacksonXmlElementWrapper(localName = "recording_users")
+  @JacksonXmlProperty(localName = "externalUserId")
+  private String[] recordingUsersExternalId;
 
   private String size;
 
@@ -221,6 +229,14 @@ public class RecordingMetadata {
 
   public String getRawSize() {
     return rawSize;
+  }
+
+  public void setRecordingUsersExternalId(String[] recordingUsersExternalId) {
+    this.recordingUsersExternalId = recordingUsersExternalId;
+  }
+
+  public String[] getRecordingUsersExternalId() {
+    return recordingUsersExternalId;
   }
 
   public String getSize() {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/RecordingResponse.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/RecordingResponse.java
@@ -23,6 +23,7 @@ public class RecordingResponse {
   private String rawSize;
   private Breakout breakout;
   private BreakoutRoom[] breakoutRooms;
+  private String[] recordingUsersExternalId;
   private Metadata metadata;
   private List<RecordingMetadataPlayback> playbacks = new ArrayList();
   private String metadataXml;
@@ -108,6 +109,14 @@ public class RecordingResponse {
 
   public BreakoutRoom[] getBreakoutRooms() {
     return breakoutRooms;
+  }
+
+  public void setRecordingUsersExternalId(String[] recordingUsersExternalId) {
+    this.recordingUsersExternalId = recordingUsersExternalId;
+  }
+
+  public String[] getRecordingUsersExternalId() {
+    return recordingUsersExternalId;
   }
 
   public void setMeta(Metadata metadata) {
@@ -217,6 +226,7 @@ public class RecordingResponse {
       this.setParticipants(recordingMetadata.getParticipants());
       this.setMeeting(recordingMetadata.getMeeting());
       this.setRawSize(recordingMetadata.getRawSize());
+      this.setRecordingUsersExternalId(recordingMetadata.getRecordingUsersExternalId());
       this.setBreakout(recordingMetadata.getBreakout());
       this.setBreakoutRooms(recordingMetadata.getBreakoutRooms());
       this.setMeta(recordingMetadata.getMeta());

--- a/bigbluebutton-web/web-app/WEB-INF/freemarker/include-recording.ftlx
+++ b/bigbluebutton-web/web-app/WEB-INF/freemarker/include-recording.ftlx
@@ -21,6 +21,18 @@
     <participants>${r.getParticipants()}</participants>
 </#if>
 
+<#if r.getRecordingUsersExternalId()??>
+<#list r.getRecordingUsersExternalId()>
+  <recordingUsers>
+    <#items as externalUserId>
+      <user>
+        <externalUserID>${externalUserId}</externalUserID>
+      </user>
+    </#items>
+  </recordingUsers>
+</#list>
+</#if>
+
 <#if r.getBreakout()??>
     <#assign breakout = r.getBreakout()>
     <breakout>

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -48,6 +48,34 @@ module BigBlueButton
       participants_ids.length
     end
 
+    def self.get_recording_users_external_id(events_xml)
+      BigBlueButton.logger.info("Task: Getting users that activated recording")
+      doc = Nokogiri::XML(File.open(events_xml))
+      recording_users_external_id = []
+      doc.xpath("//event[@eventname='RecordStatusEvent']").each do |e|
+        user_id = e.xpath(".//userId").text
+        if e.xpath(".//status").text == "true"
+          user_external_id = BigBlueButton::Events.get_user_external_id(events_xml, user_id)
+          if !recording_users_external_id.include?(user_external_id)
+            recording_users_external_id << user_external_id
+          end
+        end
+      end
+      recording_users_external_id
+    end
+
+    def self.get_user_external_id(events_xml, user_id)
+      doc = Nokogiri::XML(File.open(events_xml))
+      user_external_id = ""
+      doc.xpath("//event[@eventname='ParticipantJoinEvent']").each do |e|
+        if (e.xpath(".//userId").text == user_id)
+          user_external_id = e.xpath(".//externalUserId").text
+          break
+        end
+      end
+      user_external_id
+    end
+
     # Get the meeting metadata
     def self.get_meeting_metadata(events_xml)
       BigBlueButton.logger.info("Task: Getting meeting metadata")

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -70,6 +70,7 @@ if not FileTest.directory?(target_dir)
       b.start_time
       b.end_time
       b.participants
+      b.recording_users
       b.playback
       b.meta
     }
@@ -130,6 +131,19 @@ if not FileTest.directory?(target_dir)
 
     participants = recording.at_xpath("participants")
     participants.content = BigBlueButton::Events.get_num_participants("#{target_dir}/events.xml")
+
+    ## Remove empty recording_users
+    metadata.search('//recording/recording_users').each do |recording_users|
+      recording_users.remove
+    end
+    ## Add the actual recording_users
+    Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
+      xml.recording_users do
+        BigBlueButton::Events.get_recording_users_external_id("#{target_dir}/events.xml").each { |external_user_id|
+          xml.externalUserId(external_user_id)
+        }
+      end
+    end
 
     ## Remove empty meta
     metadata.search('//recording/meta').each do |meta|


### PR DESCRIPTION
…he recording during the meeting

getRecordings should look like this:
```
<recordings>
    <recording>
        <recordID>a64e2a4adcc4ae20e6e35babd2a181619cb8e224-1511284588665</recordID>
        ...
        <recordingUsers>
            <user>
                <externalUserId>345y</externalUserId>
            </user>
            <user>
                <externalUserId>345y4r34r34r</externalUserId>
            </user>
        </recordingUsers>
        ...
    </recording>
</recordings>
```