### PR TITLE
Avoid issues when parsing branding XML values

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/Config.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/Config.as
@@ -101,11 +101,11 @@ package org.bigbluebutton.core.model
     	
 		public function get branding():Object{
 			var a:Object = new Object();
-			a.copyright = config.branding.@copyright;
-			a.logo = config.branding.@logo;
-			a.background = config.branding.@background;
-			a.toolbarColor = config.branding.@toolbarColor;
-			a.toolbarColorAlphas = config.branding.@toolbarColorAlphas;
+			a.copyright = config.branding.@copyright.toString();
+			a.logo = config.branding.@logo.toString();
+			a.background = config.branding.@background.toString();
+			a.toolbarColor = config.branding.@toolbarColor.toString();
+			a.toolbarColorAlphas = config.branding.@toolbarColorAlphas.toString();
 			return a
 		}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -378,20 +378,21 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						
 			private function handleConfigLoadedEvent(e:ConfigLoadedEvent):void{
 				var config:Config = BBB.getConfigManager().config;
+				var branding:Object = config.branding;
 				shortcutKeysBtn.includeInLayout = shortcutKeysBtn.visible = config.shortcutKeys.showButton;
 
-				if (config.branding.logo == "") {
+				if (branding.logo == "") {
 					hideLogo();
 				} else {
-					logo.source = config.branding.logo;
+					logo.source = branding.logo;
 				}
 
-				if (config.branding.toolbarColor != "") {
-					setStyle("backgroundColor", config.branding.toolbarColor);
+				if (branding.toolbarColor != "") {
+					setStyle("backgroundColor", branding.toolbarColor);
 				}
 
-				if (config.branding.toolbarColorAlphas != "") {
-					setStyle("highlightAlphas", config.branding.toolbarColorAlphas.split(","));
+				if (branding.toolbarColorAlphas != "") {
+					setStyle("highlightAlphas", branding.toolbarColorAlphas.split(","));
 				}
 			}
 			


### PR DESCRIPTION
Now forcing the return of an object of Strings. Colors with the hash code identification will work again. 