### PR TITLE
Changing screenshare tab name

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -1010,7 +1010,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 				if (paused) {
 					paused = false;
-					screenshareTab.label = ResourceUtil.getInstance().getString('bbb.screensharePublish.title');
+					screenshareTab.label = ResourceUtil.getInstance().getString('bbb.screenshareView.title');
 					dispatchEvent(new RequestToRestartSharing());
 				} else {
 					startDeskshareTabCreation();
@@ -1177,7 +1177,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mx:VBox id="presentationTab" label="{currentPresentation}" width="100%" height="100%" paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" verticalAlign="middle" horizontalAlign="center" backgroundAlpha="0.0" verticalScrollPolicy="off" horizontalScrollPolicy="off">
 			<views:SlideView id="slideView" width="100%" height="100%" visible="false" mouseDown="mouseDown = true" mouseUp="mouseDown = false" verticalScrollPolicy="off" horizontalScrollPolicy="off"/>
 		</mx:VBox>
-		<mx:VBox id="screenshareTab" label="{ResourceUtil.getInstance().getString('bbb.screensharePublish.title')}" width="100%" height="100%" paddingTop="7" paddingBottom="0" paddingLeft="0" paddingRight="0" verticalAlign="middle" horizontalAlign="center" backgroundAlpha="0.0"/>
+		<mx:VBox id="screenshareTab" label="{ResourceUtil.getInstance().getString('bbb.screenshareView.title')}" width="100%" height="100%" paddingTop="7" paddingBottom="0" paddingLeft="0" paddingRight="0" verticalAlign="middle" horizontalAlign="center" backgroundAlpha="0.0"/>
 	</mx:TabNavigator>
 
 	<mx:ControlBar id="presCtrlBar" name="presCtrlBar" width="100%" verticalAlign="middle" styleName="presentationWindowControlsStyle" paddingTop="2" paddingBottom="2">

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
@@ -426,10 +426,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       override protected function resourcesChanged():void{
         super.resourcesChanged();
 /*
-        this.title = ResourceUtil.getInstance().getString('bbb.screensharePublish.title');
+        this.title = ResourceUtil.getInstance().getString('bbb.screenshareView.title');
         
         if (titleBarOverlay != null) {
-          titleBarOverlay.accessibilityName = ResourceUtil.getInstance().getString('bbb.screensharePublish.title');
+          titleBarOverlay.accessibilityName = ResourceUtil.getInstance().getString('bbb.screenshareView.title');
         }
         
         if (windowControls != null) {


### PR DESCRIPTION
From "Screen Sharing: Presenter's Preview" to just "Screen Sharing"