### PR TITLE
Fix webm encoding parameters

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/video.rb
@@ -61,7 +61,7 @@ module BigBlueButton
         :extension => 'webm',
         :parameters => [
           [ '-c:v', 'libvpx',
-            '-crf', '34', '-b:v', '60M', '-threads', '2', '-deadline', 'good', '-cpu-used', '3',
+            '-crf', '23', '-b:v', '60M', '-threads', '2',
             '-c:a', 'libvorbis',
             '-q:a', '2',
             '-f', 'webm' ]
@@ -102,7 +102,7 @@ module BigBlueButton
         :extension => 'webm',
         :parameters => [
           [ '-c:v', 'libvpx',
-            '-crf', '34', '-b:v', '60M', '-threads', '2', '-deadline', 'good', '-cpu-used', '3',
+            '-crf', '23', '-b:v', '60M', '-threads', '2',
             '-c:a', 'libvorbis',
             '-q:a', '2',
             '-f', 'webm' ]


### PR DESCRIPTION
Remove deadline and cpu-used parameters from webm encoder, not available on ffmpeg 3