### PR TITLE
02 05 18 fixes

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -141,6 +141,7 @@
 
     <script src="lib/kurento-utils.js" language="javascript"></script>
     <script src="lib/kurento-extension.js" language="javascript"></script>
+    <script src="lib/screenshare-adapter.min.js" language="javascript"></script>
 
     <script src="lib/bbb_api_bridge.js?v=VERSION" language="javascript"></script>
     <script src="lib/sip.js?v=VERSION" language="javascript"></script>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/BrowserCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/BrowserCheck.as
@@ -29,8 +29,9 @@ package org.bigbluebutton.modules.screenshare.utils
 		private static const LOGGER:ILogger = getClassLogger(BrowserCheck);
 
 		public static function isWebRTCSupported():Boolean {
-			/*LOGGER.debug("isWebRTCSupported - ExternalInterface.available=[{0}], isWebRTCAvailable=[{1}]", [ExternalInterface.available, ExternalInterface.call("isWebRTCAvailable")]);*/
-			return (ExternalInterface.available && ExternalInterface.call("isWebRTCAvailable"));
+			// TODO: Right now we can only privide support for Chrome and Firefox WebRTC screen share
+			var isWebRTCAvailable:Boolean = ExternalInterface.available && ExternalInterface.call("isWebRTCAvailable");
+			return isWebRTCAvailable && (isChrome() || isFirefox());
 		}
 
 		public static function isChrome():Boolean {


### PR DESCRIPTION
- missing screenshare-adapter lib in HTML
- only allow WebRTC screenshare in Chrome and Firefox