### PR TITLE
Scaling WebRTC screenshare video

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -40,8 +40,8 @@ Kurento = function (
   this.userId = userId;
   this.userName = userName;
 
-  this.vid_width = window.screen.width;
-  this.vid_height = window.screen.height;
+  this.vid_width = window.screen.width/2;
+  this.vid_height = window.screen.height/2;
 
   // TODO properly generate a uuid
   this.sessid = Math.random().toString();


### PR DESCRIPTION
A simple scaling to the WebRTC screenshare video to make it lighter at the server. We already use this scaling at Mconf Deskshare video profile. We should rethink this once we implement the profile feature for WebRTC also.