### PR TITLE
Avoid displaying the playback interface before the media is playable

### DIFF
--- a/record-and-playback/presentation/playback/presentation/0.9.0/acornmediaplayer/jquery.acornmediaplayer.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/acornmediaplayer/jquery.acornmediaplayer.js
@@ -318,9 +318,7 @@
 			 * Pauses the media during seek and changes the "currentTime" to the slider's value
 			 */
 			var startSeek = function(e, ui) {					
-				if(!acorn.$self.attr('paused')) {
-					wasPlaying = true;
-				}
+				acorn.$playBtn.prop('disabled', true);
 				acorn.$self.trigger('pause');
 				seeking = true;
 				
@@ -343,14 +341,11 @@
 			 * and updates ARIA attributes
 			 */
 			var endSeek = function(e, ui) {
-				if(wasPlaying) {
-					acorn.$self.trigger('play');
-					wasPlaying = false;
-				}
 				seeking = false;			
 				var sliderUI = $(ui.handle);
 				sliderUI.attr("aria-valuenow", parseInt(ui.value, 10));
 				sliderUI.attr("aria-valuetext", ariaTimeFormat(ui.value));
+				acorn.$playBtn.prop('disabled', false);
 			};
 			
 			/*

--- a/record-and-playback/presentation/playback/presentation/0.9.0/acornmediaplayer/themes/bigbluebutton/acorn.bigbluebutton.css
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/acornmediaplayer/themes/bigbluebutton/acorn.bigbluebutton.css
@@ -110,7 +110,7 @@
   background: #289ad6;
 }
 .acorn-player.bigbluebutton .acorn-buffer {
-  background: #8E9DAF !important;
+  background: #9ad0ec !important;
 }
 .acorn-player.bigbluebutton .acorn-seek-slider .ui-state-focus, .acorn-player.bigbluebutton .acorn-seek-slider .ui-slider-handle.ui-state-hover {
   background: #fff !important;

--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
@@ -229,15 +229,17 @@ function startLoadingBar() {
   console.log("==Hide playback content");
   $("#playback-content").css('visibility', 'hidden');
   Pace.once('done', function() {
-    $("#loading-error").css('height','0');
-    console.log("==Show playback content");
-    $("#playback-content").css('visibility', 'visible');
+    document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'page'}));
   });
   Pace.start();
 }
 
 function runPopcorn() {
   console.log("** Running popcorn");
+
+  $("#loading-error").css('height','0');
+  console.log("==Show playback content");
+  $("#playback-content").css('visibility', 'visible');
 
   getMetadata();
 
@@ -678,6 +680,7 @@ var svgReady = false;
 var videoReady = false;
 var audioReady = false;
 var deskshareReady = false;
+var pageReady = false;
 
 var svgobj = document.createElement('object');
 svgobj.setAttribute('data', shapes_svg);
@@ -699,11 +702,14 @@ document.addEventListener('media-ready', function(event) {
     case 'svg':
       svgReady = true;
       break;
+    case 'page':
+      pageReady = true;
+      break;
     default:
       console.log('unhandled media-ready event: ' + event.detail);
   }
 
-  if ((audioReady || videoReady) && deskshareReady && svgReady) {
+  if ((audioReady || videoReady) && deskshareReady && svgReady && pageReady) {
     runPopcorn();
 
     if (firstLoad) initPopcorn();

--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
@@ -228,7 +228,7 @@ function handlePresentationAreaContent(time) {
 function startLoadingBar() {
   console.log("==Hide playback content");
   $("#playback-content").css('visibility', 'hidden');
-  Pace.once('done', function() {
+  Pace.on('done', function() {
     document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'page'}));
   });
   Pace.start();
@@ -236,10 +236,6 @@ function startLoadingBar() {
 
 function runPopcorn() {
   console.log("** Running popcorn");
-
-  $("#loading-error").css('height','0');
-  console.log("==Show playback content");
-  $("#playback-content").css('visibility', 'visible');
 
   getMetadata();
 
@@ -680,7 +676,10 @@ var svgReady = false;
 var videoReady = false;
 var audioReady = false;
 var deskshareReady = false;
-var pageReady = false;
+
+var isPlaybackReady = function() {
+ return (audioReady || videoReady) && deskshareReady && svgReady;
+}
 
 var svgobj = document.createElement('object');
 svgobj.setAttribute('data', shapes_svg);
@@ -703,13 +702,20 @@ document.addEventListener('media-ready', function(event) {
       svgReady = true;
       break;
     case 'page':
-      pageReady = true;
+      if (isPlaybackReady()) {
+        $("#loading-error").css('height','0');
+        console.log("==Show playback content");
+        $("#playback-content").css('visibility', 'visible');
+      } else {
+        console.warn("==Missing some objects");
+        Pace.restart();
+      }
       break;
     default:
       console.log('unhandled media-ready event: ' + event.detail);
   }
 
-  if ((audioReady || videoReady) && deskshareReady && svgReady && pageReady) {
+  if (isPlaybackReady()) {
     runPopcorn();
 
     if (firstLoad) initPopcorn();

--- a/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
@@ -461,7 +461,7 @@ function setSync() {
        });
 
 
-       allMedias[i].on("canplaythrough", function() {
+       allMedias[i].on("canplay", function() {
           if(syncing || masterVideoSeeked) {
               var allMediasAreReady = true;
               for(i = 0; i < allMedias.length ; i++)
@@ -484,7 +484,7 @@ function sync() {
      if(secondaryMedias[i].media.readyState > 1) {
         secondaryMedias[i].pause();
 
-        //set the current time will fire a "canplaythrough" event to tell us that the video can be played...
+        //set the current time will fire a "canplay" event to tell us that the video can be played...
         secondaryMedias[i].currentTime(primaryMedia.currentTime());
      }
   }

--- a/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
@@ -348,7 +348,7 @@ load_video = function(){
 
    document.getElementById("video-area").appendChild(video);
 
-   Popcorn("#video").on("canplayall", function() {
+   Popcorn("#video").on("canplay", function() {
       console.log("==Video loaded");
       document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'video'}));
    });
@@ -387,7 +387,7 @@ load_audio = function() {
    document.getElementById("audio-area").appendChild(audio);
 
    //remember: audio id is 'video'
-   Popcorn("#video").on("canplayall", function() {
+   Popcorn("#video").on("canplay", function() {
       console.log("==Audio loaded");
       document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'audio'}));
    });
@@ -408,7 +408,7 @@ load_deskshare_video = function () {
 
    setSync();
 
-   Popcorn("#deskshare-video").on("canplayall", function() {
+   Popcorn("#deskshare-video").on("canplay", function() {
       console.log("==Deskshare video loaded");
       document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'deskshare'}));
    });


### PR DESCRIPTION
We received some complains about slow Internet connections trying to watch the meeting recordings.
The major issue here is probably the loading bar object that was displaying the playback interface before the media files were ready to play. Changed this to include the loading bar completion as an event to merge with the current events structure we listen to.
The other problem I noticed was that the event we listen to signal media-ready for the video files (_canplayall_) is an event that doesn't fit in this slow Internet use case either. The next close event we could use is _canplaythrough_. It isn't a good option either because this kind of user will never get this event unless the media is completely loaded. I made some tests using just _canplay_ and maybe this is the way to go.